### PR TITLE
Fixed src/privileges/posts.js: canEdit - Too many return statements

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -133,12 +133,14 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: true };
 	}
 
+	let errorMessage = null;
+
 	if (
 		!isRemote && !results.isMod &&
 		meta.config.postEditDuration &&
 		(Date.now() - results.postData.timestamp > meta.config.postEditDuration * 1000)
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]`;
 	}
 	if (
 		!isRemote && !results.isMod &&
@@ -146,16 +148,20 @@ privsPosts.canEdit = async function (pid, uid) {
 		meta.config.newbieReputationThreshold > results.userData.reputation &&
 		Date.now() - results.postData.timestamp > meta.config.newbiePostEditDuration * 1000
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]`;
 	}
 
 	const isLocked = await topics.isLocked(results.postData.tid);
 	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
+		errorMessage = '[[error:topic-locked]]';
 	}
 
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
+		errorMessage = '[[error:post-deleted]]';
+	}
+
+	if (errorMessage) {
+		return { flag: false, message: errorMessage };
 	}
 
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;


### PR DESCRIPTION
Fixed the issue with the canEdit function within src/privileges/posts.js where it had too many return statements. This code is from my P1A. 