### PR TITLE
feat: Display content preview for pinned topics on category board

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,6 +23,11 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
+					{{{ if ./pinned && ./contentPreview }}}
+					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
+						{./contentPreview}
+					</div>
+					{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,11 +23,15 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
-					{{{ if ./pinned && ./contentPreview }}}
-					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
-						{./contentPreview}
-					</div>
-					{{{ end }}}
+				{{{ if ./pinned }}}
+				<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break w-100">
+    				{{{ if ./contentPreview }}}
+            	{{ ./contentPreview }}
+        		{{{ else }}}
+            	No preview available
+        		{{{ end }}}
+				</div>
+				{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>


### PR DESCRIPTION
Added a new UI feature that displays a content preview for pinned topics when viewing a category board. The preview shows the sanitized text from the first post of each pinned topic, allowing users to get a glimpse of the content without opening the topic.

- Modified: vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl

- Utilizes existing pinned property to identify pinned topics

- Uses new contentPreview data field provided by backend services

(See https://github.com/CMU-313/nodebb-fall-2025-slackers2/issues/24)